### PR TITLE
fix: Dockerfileにapt-get upgradeを追加してTrivyセキュリティスキャン失敗を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,20 @@ RUN uv sync --frozen --no-dev
 COPY ./static ./static
 COPY ./templates ./templates
 
-# 7. ファイルの所有権を変更し、非rootユーザーに切り替え
+# 7. OSパッケージをアップデート（セキュリティ修正）
+# NOTE: ビルドキャッシュ効率のため、アプリケーション層の後に配置
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+# 8. ファイルの所有権を変更し、非rootユーザーに切り替え
 RUN chown -R appuser:appgroup $APP_HOME
 USER appuser
 
-# 8. ポートを公開
+# 9. ポートを公開
 EXPOSE 80
 
-# 9. ヘルスチェック
+# 10. ヘルスチェック
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
 
-# 10. アプリケーションを起動するコマンド
+# 11. アプリケーションを起動するコマンド
 CMD ["uv", "run", "uvicorn", "html_tool_manager.main:app", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
## Summary
- Dockerfileにapt-get upgradeステップを追加し、ベースイメージのOSパッケージを最新状態に更新
- GitHub Actions run #19783870880 でのTrivyセキュリティスキャン失敗を修正

## 背景
CIでのDockerイメージビルド時にTrivyがHIGH/CRITICAL脆弱性を検出してワークフローが失敗していました。ベースイメージに含まれる古いパッケージに脆弱性があったため、apt-get upgradeを追加することで解決しました。

## Test plan
- [x] ローカルでDockerビルドが成功することを確認
- [x] ローカルでTrivy v0.65.0スキャンで脆弱性0件を確認
- [ ] CIでTrivyスキャンがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)