### PR TITLE
fix: PRマージ時のリリース判定条件を修正

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      contains(github.event.head_commit.message, 'chore: bump version')
+      contains(github.event.head_commit.message, 'release/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 問題

リリースPRをマージしても、GitHub Actionsのタグ作成・Dockerビルドがスキップされる問題。

### 原因

`create-tag` ジョブの条件が `contains(github.event.head_commit.message, 'chore: bump version')` だったが、PRマージ時の `head_commit.message` はマージコミットのメッセージ（例: `Merge pull request #16 from ebal5/release/v0.1.2`）になるため、条件がマッチしなかった。

## 修正内容

判定条件を `contains(github.event.head_commit.message, 'release/v')` に変更。
マージコミットメッセージにはブランチ名 `release/v*` が含まれるため、これで正しく検出できる。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)