### PR TITLE
fix: pyproject.tomlからのバージョン抽出を修正

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Extract version from pyproject.toml
         id: version
         run: |
-          VERSION=$(grep -Po '(?<=version = ")[^"]+' pyproject.toml)
+          VERSION=$(grep -Po '^version = "\K[^"]+' pyproject.toml)
           echo "version=v$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: v$VERSION"
 


### PR DESCRIPTION
## 問題

GitHub Actionsの `create-tag` ジョブが失敗。

### エラー
```
Invalid format 'py312'
Unable to process file command 'output' successfully
```

### 原因

`grep -Po '(?<=version = ")[^"]+'` が pyproject.toml 内の複数の "version" 文字列にマッチしていた:
- `version = "0.1.3"` → 0.1.3 ✅
- `target-version = "py312"` → py312 ❌
- `python_version = "3.12"` → 3.12 ❌

## 修正内容

パターンを `^version = "\K[^"]+` に変更し、行頭の `version = ` のみにマッチするように修正。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)