### PR TITLE
feat: add Docker security scan for release branch PRs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag_created: ${{ steps.create_tag.outputs.created }}
+      should_release: ${{ steps.create_tag.outputs.created == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,16 +65,26 @@ jobs:
           echo "created=true" >> $GITHUB_OUTPUT
           echo "Created and pushed tag ${{ steps.version.outputs.version }}"
 
-  build-and-push:
+  security-scan:
     needs: create-tag
     if: |
       always() &&
       (needs.create-tag.outputs.tag_created == 'true' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/docker-scan.yml
+    permissions:
+      contents: read
+      security-events: write
+
+  build-and-push:
+    needs: [create-tag, security-scan]
+    if: |
+      always() &&
+      (needs.create-tag.outputs.tag_created == 'true' || github.event_name == 'workflow_dispatch') &&
+      needs.security-scan.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
-      security-events: write
 
     steps:
       - name: Checkout repository
@@ -120,31 +131,6 @@ jobs:
             type=raw,value=${{ steps.get_version.outputs.major_minor }},enable=${{ steps.get_version.outputs.major_minor != '' }}
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ startsWith(steps.get_version.outputs.version, 'v') && !contains(steps.get_version.outputs.version, '-') }}
-
-      - name: Build Docker image for scanning
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          load: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
-          cache-from: type=gha
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -1,0 +1,73 @@
+name: Docker Security Scan
+
+on:
+  workflow_call:
+    inputs:
+      upload-sarif:
+        description: "Upload scan results to GitHub Security tab"
+        required: false
+        default: true
+        type: boolean
+    outputs:
+      scan-passed:
+        description: "Whether the security scan passed"
+        value: ${{ jobs.scan.outputs.passed }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    outputs:
+      passed: ${{ steps.scan-result.outputs.passed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha
+
+      - name: Run Trivy vulnerability scanner
+        id: trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:scan"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+        continue-on-error: true
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: inputs.upload-sarif && always()
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Set scan result
+        id: scan-result
+        run: |
+          if [ "${{ steps.trivy.outcome }}" == "success" ]; then
+            echo "passed=true" >> $GITHUB_OUTPUT
+            echo "Security scan passed"
+          else
+            echo "passed=false" >> $GITHUB_OUTPUT
+            echo "Security scan failed - vulnerabilities found"
+            exit 1
+          fi

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,23 @@
+name: Release Branch Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-release-branch:
+    # Only run for PRs from release/* branches
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release branch detected
+        run: echo "Running release checks for branch ${{ github.head_ref }}"
+
+  docker-security-scan:
+    needs: check-release-branch
+    if: startsWith(github.head_ref, 'release/')
+    uses: ./.github/workflows/docker-scan.yml
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Summary

- リリースブランチ (`release/*`) からのPRでDockerセキュリティスキャン（Trivy）を実行
- 再利用可能ワークフロー `docker-scan.yml` を新規作成
- `docker-publish.yml` をリファクタリングして同一のスキャンロジックを使用

## 変更内容

### 新規ファイル
- `.github/workflows/docker-scan.yml` - 再利用可能なTrivyスキャンワークフロー
- `.github/workflows/release-check.yml` - リリースブランチPR用チェック

### 修正ファイル
- `.github/workflows/docker-publish.yml` - スキャンを共通化

## ワークフロー

```
リリースブランチPR時:
  release-check.yml → docker-scan.yml → (スキャン)

リリース（mainマージ）時:
  docker-publish.yml
    ├─ create-tag
    ├─ security-scan → docker-scan.yml → (スキャン)
    └─ build-and-push (スキャン成功時のみ)
```

## Test plan

- [ ] `release/*` ブランチからのPRでdocker-security-scanジョブが実行されることを確認
- [ ] 通常のブランチからのPRではスキャンがスキップされることを確認
- [ ] リリース時にスキャン→ビルド→プッシュの順序で実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)