### PR TITLE
fix: Docker起動時の開発依存関係再インストール問題を修正

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -90,9 +90,9 @@ argument-hint: [version: patch|minor|major|x.y.z]
 
 2. **ポート使用状況の確認**
    ```bash
-   curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/ 2>/dev/null || echo "port_free"
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/ 2>/dev/null || echo "port_free"
    ```
-   - ポート8888が使用中の場合: 使用中のサービスを報告し、停止を促して中断
+   - ポート8080が使用中の場合: 使用中のサービスを報告し、停止を促して中断
 
 3. **ビルド**
    ```bash
@@ -101,7 +101,7 @@ argument-hint: [version: patch|minor|major|x.y.z]
 
 4. **起動**
    ```bash
-   docker run -d -p 8888:80 --name htm-release-test html-tool-manager:release-test
+   docker run -d -p 8080:80 --name htm-release-test html-tool-manager:release-test
    ```
 
 5. **ヘルスチェック**（リトライ付き）
@@ -109,7 +109,7 @@ argument-hint: [version: patch|minor|major|x.y.z]
      ```bash
      HEALTH_STATUS="unhealthy"
      for i in 1 2 3 4 5 6; do
-       if curl -s -f http://localhost:8888/ > /dev/null 2>&1; then
+       if curl -s -f http://localhost:8080/ > /dev/null 2>&1; then
          HEALTH_STATUS="healthy"
          break
        fi
@@ -168,18 +168,21 @@ argument-hint: [version: patch|minor|major|x.y.z]
 2. **pyproject.toml のバージョンを更新**
    - Editツールで `version = "x.y.z"` の行を新しいバージョンに書き換える
 
-3. **変更をコミット**
+3. **README.md のDockerイメージバージョンを更新**
+   - Editツールで `docker pull ghcr.io/ebal5/html-tool-manager:x.y.z` の行を新しいバージョンに書き換える
+
+4. **変更をコミット**
    ```bash
-   git add pyproject.toml
+   git add pyproject.toml uv.lock README.md
    git commit -m "chore: bump version to <version>"
    ```
 
-4. **ブランチをプッシュ**
+5. **ブランチをプッシュ**
    ```bash
    git push -u origin release/v<version>
    ```
 
-5. **PRを作成**
+6. **PRを作成**
    - 変更履歴を整形してPR本文を作成
    ```bash
    gh pr create --title "Release v<version>" --body "$(cat <<'EOF'
@@ -194,12 +197,12 @@ argument-hint: [version: patch|minor|major|x.y.z]
    )"
    ```
 
-6. **mainブランチに戻る**
+7. **mainブランチに戻る**
    ```bash
    git checkout main
    ```
 
-7. **完了報告**
+8. **完了報告**
    - 作成されたPR URLを表示
    - 「PRをマージすると、GitHub Actionsが自動でタグ `v<version>` とリリースを作成します」と案内
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+.venv
+venv/
+
+# Testing
+tests/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Linting/Type checking
+.mypy_cache/
+.ruff_cache/
+
+# Documentation
+docs/
+*.md
+
+# IDE
+.idea/
+.vscode/
+
+# CI/CD
+.github/
+
+# Claude Code
+.claude/
+
+# Local development
+sql_app.db
+sql_app.db-journal
+.env
+.env.*
+*.log
+
+# User content (use volumes)
+static/tools/

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
 
 # 11. アプリケーションを起動するコマンド
-CMD ["uv", "run", "uvicorn", "html_tool_manager.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uv", "run", "--no-sync", "uvicorn", "html_tool_manager.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/README.md
+++ b/README.md
@@ -89,20 +89,20 @@
 docker pull ghcr.io/ebal5/html-tool-manager:latest
 
 # 特定バージョンを取得
-docker pull ghcr.io/ebal5/html-tool-manager:0.1.0
+docker pull ghcr.io/ebal5/html-tool-manager:0.1.5
 ```
 
 **コンテナの実行:**
 
 ```bash
-docker run -d -p 8888:80 \
+docker run -d -p 8080:80 \
   -v html-tool-manager-data:/app/static/tools \
   -v html-tool-manager-db:/app \
   --name html-tool-manager-app \
   ghcr.io/ebal5/html-tool-manager:latest
 ```
 
-アプリケーションは `http://127.0.0.1:8888` で利用可能になります。
+アプリケーションは `http://127.0.0.1:8080` で利用可能になります。
 
 #### ローカルでビルド
 
@@ -113,7 +113,7 @@ docker run -d -p 8888:80 \
 
 2.  **Dockerコンテナの実行:**
     ```bash
-    docker run -d -p 8888:80 \
+    docker run -d -p 8080:80 \
       -v html-tool-manager-data:/app/static/tools \
       -v html-tool-manager-db:/app \
       --name html-tool-manager-app \


### PR DESCRIPTION
## Summary
- **Dockerfile**: `uv run --no-sync` オプションを追加して、コンテナ起動時の開発依存関係（42パッケージ）の再インストールを防止
- **.dockerignore**: 新規作成し、不要ファイル（.git, tests, docs, .claude 等）をビルドコンテキストから除外
- **release.md**: リリースプロセスを改善
  - `git add` に `uv.lock` と `README.md` を追加
  - ドキュメント内のポート番号を `8080` に統一
- **README.md**: Docker イメージバージョンを `0.1.5` に更新、ポート番号を `8080` に統一

## Background
v0.1.5 リリース後に以下の問題が報告されていました：
1. Docker コンテナ起動時に開発依存関係が毎回ダウンロード・インストールされ、起動に10秒以上かかる
2. リリースPRで `uv.lock` と README.md のイメージバージョンが更新されていなかった
3. ドキュメント内のポート番号に不一致があった（8080 vs 8888）

## Test plan
- [x] Docker イメージをビルド
- [x] コンテナ起動が数秒以内で完了することを確認（開発依存の再インストールなし）
- [x] ヘルスチェックが正常に通ることを確認
- [x] アプリケーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)