### PR TITLE
Release v0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 docker pull ghcr.io/ebal5/html-tool-manager:latest
 
 # 特定バージョンを取得
-docker pull ghcr.io/ebal5/html-tool-manager:0.1.5
+docker pull ghcr.io/ebal5/html-tool-manager:0.1.6
 ```
 
 **コンテナの実行:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ sources = ["src"]
 
 [project]
 name = "html-tool-manager"
-version = "0.1.5"
+version = "0.1.6"
 description = "HTML/JS tools manager"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "html-tool-manager"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Release v0.1.6

### Changes since v0.1.5

- **feat**: PlaywrightによるE2Eテストを追加
- **fix**: urllib3の脆弱性を修正（2.5.0 → 2.6.1）
- **fix**: Docker起動時の開発依存関係再インストール問題を修正
- **fix**: E2Eテストのデバッグ性・信頼性を向上
- **fix**: CIのtestジョブでE2Eテストを除外
- **fix**: allowed-toolsにdocker ps, docker logs, echoを追加
- **refactor**: リリースコマンドのフロー改善

---
マージ後、GitHub Actionsが自動でタグとリリースを作成します。