### PR TITLE
fix(security): ファイル書き込みの原子性を確保

### DIFF
--- a/src/html_tool_manager/api/snapshots.py
+++ b/src/html_tool_manager/api/snapshots.py
@@ -8,6 +8,7 @@ from sqlmodel import Session
 
 from html_tool_manager.core.config import app_settings
 from html_tool_manager.core.db import get_session
+from html_tool_manager.core.file_utils import atomic_write_file
 from html_tool_manager.core.security import is_path_within_base
 from html_tool_manager.models import (
     SnapshotCreate,
@@ -183,8 +184,7 @@ def restore_snapshot(
 
     # Write file first - if this fails, no DB changes are made
     try:
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write(content_to_write)
+        atomic_write_file(filepath, content_to_write)
     except PermissionError:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/html_tool_manager/api/tools.py
+++ b/src/html_tool_manager/api/tools.py
@@ -7,6 +7,7 @@ from sqlmodel import Session
 
 from html_tool_manager.core.config import app_settings
 from html_tool_manager.core.db import get_session
+from html_tool_manager.core.file_utils import atomic_write_file
 from html_tool_manager.core.security import is_path_within_base
 from html_tool_manager.models import SnapshotType, ToolCreate, ToolRead
 from html_tool_manager.models.tool import NAME_MAX_LENGTH
@@ -159,8 +160,7 @@ def update_tool(tool_id: int, tool_data: ToolCreate, session: Session = Depends(
             # コンテンツサイズが上限を超える場合はスナップショット作成をスキップ
             pass
 
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write(final_html)
+        atomic_write_file(filepath, final_html)
 
     # メタデータを更新（filepathは変更不可 - セキュリティのため既存の値を維持）
     update_data = tool_data.model_dump(exclude_unset=True, exclude={"html_content", "filepath"})

--- a/src/html_tool_manager/core/file_utils.py
+++ b/src/html_tool_manager/core/file_utils.py
@@ -1,0 +1,40 @@
+"""File utilities for safe file operations."""
+
+import os
+import tempfile
+
+
+def atomic_write_file(filepath: str, content: str, mode: int = 0o644) -> None:
+    """Write content to a file atomically.
+
+    Uses a temporary file and os.replace() to ensure atomic writes.
+    This prevents file corruption if the process crashes during write.
+
+    Args:
+        filepath: The target file path to write to.
+        content: The content to write.
+        mode: File permission mode (default: 0o644).
+
+    Raises:
+        OSError: If file operations fail.
+        PermissionError: If permission is denied.
+
+    """
+    dir_path = os.path.dirname(filepath)
+
+    # Create temp file in the same directory for atomic replace
+    temp_fd, temp_path = tempfile.mkstemp(dir=dir_path, text=True)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        # Set permissions before replace
+        os.chmod(temp_path, mode)
+        # Atomic replace (works on POSIX and Windows)
+        os.replace(temp_path, filepath)
+    except BaseException:
+        # Clean up temp file on any error
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise

--- a/src/html_tool_manager/core/file_utils.py
+++ b/src/html_tool_manager/core/file_utils.py
@@ -20,7 +20,7 @@ def atomic_write_file(filepath: str, content: str, mode: int = 0o644) -> None:
         PermissionError: If permission is denied.
 
     """
-    dir_path = os.path.dirname(filepath)
+    dir_path = os.path.dirname(filepath) or "."
 
     # Create temp file in the same directory for atomic replace
     temp_fd, temp_path = tempfile.mkstemp(dir=dir_path, text=True)

--- a/src/html_tool_manager/core/file_utils.py
+++ b/src/html_tool_manager/core/file_utils.py
@@ -11,11 +11,12 @@ def atomic_write_file(filepath: str, content: str, mode: int = 0o644) -> None:
     This prevents file corruption if the process crashes during write.
 
     Args:
-        filepath: The target file path to write to.
+        filepath: The target file path to write to. Parent directory must exist.
         content: The content to write.
         mode: File permission mode (default: 0o644).
 
     Raises:
+        FileNotFoundError: If parent directory does not exist.
         OSError: If file operations fail.
         PermissionError: If permission is denied.
 

--- a/src/html_tool_manager/repositories/tool_repository.py
+++ b/src/html_tool_manager/repositories/tool_repository.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Session, select, text
 
 from html_tool_manager.core.config import app_settings
+from html_tool_manager.core.file_utils import atomic_write_file
 from html_tool_manager.core.security import is_path_within_base
 from html_tool_manager.models import Tool, ToolCreate
 from html_tool_manager.models.tool import ToolType
@@ -107,10 +108,8 @@ class ToolRepository:
         os.makedirs(tool_dir, mode=0o755, exist_ok=True)
         final_filepath = f"{tool_dir}/index.html"
 
-        # ファイルを作成し、明示的な権限を設定（owner: rw, group/other: r）
-        with open(final_filepath, "w", encoding="utf-8") as f:
-            f.write(final_html)
-        os.chmod(final_filepath, 0o644)
+        # ファイルを原子的に作成し、明示的な権限を設定（owner: rw, group/other: r）
+        atomic_write_file(final_filepath, final_html, mode=0o644)
 
         # DBに保存するモデルのfilepathを更新
         tool_data.filepath = final_filepath

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -157,3 +157,18 @@ Line 3
         atomic_write_file(str(filepath), content)
 
         assert filepath.read_text(encoding="utf-8") == content
+
+    def test_fails_when_directory_does_not_exist(self, tmp_path):
+        """Test that FileNotFoundError is raised when parent directory doesn't exist."""
+        filepath = tmp_path / "nonexistent" / "test.txt"
+
+        with pytest.raises(FileNotFoundError):
+            atomic_write_file(str(filepath), "content")
+
+    def test_filename_only_uses_current_directory(self, tmp_path, monkeypatch):
+        """Test that filename without directory uses current directory."""
+        monkeypatch.chdir(tmp_path)
+
+        atomic_write_file("test.txt", "content")
+
+        assert (tmp_path / "test.txt").read_text(encoding="utf-8") == "content"

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,159 @@
+"""Tests for file utility functions."""
+
+import os
+import stat
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from html_tool_manager.core.file_utils import atomic_write_file
+
+
+class TestAtomicWriteFile:
+    """Tests for atomic_write_file function."""
+
+    def test_writes_content_correctly(self, tmp_path):
+        """Test that content is written correctly."""
+        filepath = tmp_path / "test.txt"
+        content = "Hello, World!"
+
+        atomic_write_file(str(filepath), content)
+
+        assert filepath.read_text(encoding="utf-8") == content
+
+    def test_writes_unicode_content(self, tmp_path):
+        """Test that unicode content is written correctly."""
+        filepath = tmp_path / "test.txt"
+        content = "こんにちは世界！日本語テスト"
+
+        atomic_write_file(str(filepath), content)
+
+        assert filepath.read_text(encoding="utf-8") == content
+
+    def test_overwrites_existing_file(self, tmp_path):
+        """Test that existing file is overwritten."""
+        filepath = tmp_path / "test.txt"
+        filepath.write_text("old content", encoding="utf-8")
+
+        atomic_write_file(str(filepath), "new content")
+
+        assert filepath.read_text(encoding="utf-8") == "new content"
+
+    def test_sets_default_permissions(self, tmp_path):
+        """Test that default file permissions are set correctly."""
+        filepath = tmp_path / "test.txt"
+
+        atomic_write_file(str(filepath), "content")
+
+        # Check file permissions (ignore extra bits like sticky bit)
+        file_mode = stat.S_IMODE(os.stat(filepath).st_mode)
+        assert file_mode == 0o644
+
+    def test_sets_custom_permissions(self, tmp_path):
+        """Test that custom file permissions are set correctly."""
+        filepath = tmp_path / "test.txt"
+
+        atomic_write_file(str(filepath), "content", mode=0o600)
+
+        file_mode = stat.S_IMODE(os.stat(filepath).st_mode)
+        assert file_mode == 0o600
+
+    def test_cleans_up_temp_file_on_write_error(self, tmp_path):
+        """Test that temp file is cleaned up when write fails."""
+        filepath = tmp_path / "test.txt"
+
+        with patch("os.fdopen") as mock_fdopen:
+            mock_fdopen.side_effect = IOError("Write failed")
+            with pytest.raises(IOError):
+                atomic_write_file(str(filepath), "content")
+
+        # Verify no temp files remain
+        remaining_files = list(tmp_path.iterdir())
+        assert len(remaining_files) == 0
+
+    def test_cleans_up_temp_file_on_chmod_error(self, tmp_path):
+        """Test that temp file is cleaned up when chmod fails."""
+        filepath = tmp_path / "test.txt"
+
+        with patch("os.chmod") as mock_chmod:
+            mock_chmod.side_effect = OSError("chmod failed")
+            with pytest.raises(OSError):
+                atomic_write_file(str(filepath), "content")
+
+        # Verify no temp files remain
+        remaining_files = list(tmp_path.iterdir())
+        assert len(remaining_files) == 0
+
+    def test_atomic_replacement(self, tmp_path):
+        """Test that file replacement is atomic (uses os.replace)."""
+        filepath = tmp_path / "test.txt"
+        filepath.write_text("original", encoding="utf-8")
+
+        with patch("os.replace") as mock_replace:
+            # Let the real replace happen
+            mock_replace.side_effect = lambda src, dst: os.rename(src, dst)
+            atomic_write_file(str(filepath), "new content")
+
+            # Verify os.replace was called
+            mock_replace.assert_called_once()
+
+    def test_temp_file_created_in_same_directory(self, tmp_path):
+        """Test that temp file is created in the same directory as target."""
+        filepath = tmp_path / "test.txt"
+
+        # Create a real temp file for the test before patching
+        real_fd, real_path = tempfile.mkstemp(dir=str(tmp_path), text=True)
+
+        with patch("html_tool_manager.core.file_utils.tempfile.mkstemp") as mock_mkstemp:
+            mock_mkstemp.return_value = (real_fd, real_path)
+
+            atomic_write_file(str(filepath), "content")
+
+            # Verify mkstemp was called with correct directory
+            mock_mkstemp.assert_called_once_with(dir=str(tmp_path), text=True)
+
+    def test_raises_permission_error(self, tmp_path):
+        """Test that PermissionError is raised when directory is not writable."""
+        # Create a read-only directory
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        os.chmod(readonly_dir, 0o444)
+
+        filepath = readonly_dir / "test.txt"
+
+        try:
+            with pytest.raises(PermissionError):
+                atomic_write_file(str(filepath), "content")
+        finally:
+            # Restore permissions for cleanup
+            os.chmod(readonly_dir, 0o755)
+
+    def test_multiline_content(self, tmp_path):
+        """Test that multiline content is written correctly."""
+        filepath = tmp_path / "test.txt"
+        content = """Line 1
+Line 2
+Line 3
+"""
+
+        atomic_write_file(str(filepath), content)
+
+        assert filepath.read_text(encoding="utf-8") == content
+
+    def test_empty_content(self, tmp_path):
+        """Test that empty content is written correctly."""
+        filepath = tmp_path / "test.txt"
+
+        atomic_write_file(str(filepath), "")
+
+        assert filepath.read_text(encoding="utf-8") == ""
+
+    def test_large_content(self, tmp_path):
+        """Test that large content is written correctly."""
+        filepath = tmp_path / "test.txt"
+        content = "x" * 1_000_000  # 1MB of content
+
+        atomic_write_file(str(filepath), content)
+
+        assert filepath.read_text(encoding="utf-8") == content


### PR DESCRIPTION
## Summary
- tempfileとos.replace()を使用した原子的書き込みパターンを導入
- プロセスクラッシュ時のファイル破損を防止
- 3箇所のファイル書き込み処理を統一されたユーティリティ関数に置き換え

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `core/file_utils.py` | 新規 - `atomic_write_file()` 関数 |
| `repositories/tool_repository.py` | 原子的書き込みに変更 |
| `api/tools.py` | 原子的書き込みに変更 |
| `api/snapshots.py` | 原子的書き込みに変更 |
| `tests/test_file_utils.py` | 新規 - 13件のテストケース |

## Test plan
- [x] `atomic_write_file()` のユニットテスト（13件）
- [x] 既存テスト全件パス（211件）
- [x] lint/format チェックパス

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)