### PR TITLE
feat: カード/グリッドビュー切り替え機能を追加

### DIFF
--- a/docs/csp-policy.md
+++ b/docs/csp-policy.md
@@ -1,0 +1,124 @@
+# Content Security Policy (CSP) 対応方針
+
+## 概要
+
+このプロジェクトでは、XSS（クロスサイトスクリプティング）攻撃を防ぐため、Content Security Policyを実装しています。
+
+## CSP設定の実装
+
+### 設定場所
+
+`src/html_tool_manager/main.py` のセキュリティミドルウェア内で設定しています。
+
+### 現在のCSPポリシー
+
+```
+default-src 'self';
+script-src 'self' https://unpkg.com https://cdn.jsdelivr.net https://cdn.tailwindcss.com 'unsafe-inline' 'unsafe-eval';
+style-src 'self' https://cdn.jsdelivr.net https://cdn.tailwindcss.com 'unsafe-inline';
+img-src 'self' data:;
+connect-src 'self' https://cdn.jsdelivr.net;
+worker-src 'self' blob:;
+frame-ancestors 'none';
+base-uri 'self';
+```
+
+### ディレクティブの説明
+
+| ディレクティブ | 設定値 | 理由 |
+|---------------|--------|------|
+| `default-src` | `'self'` | デフォルトは同一オリジンのみ許可 |
+| `script-src` | `'self'` + CDN + `'unsafe-inline'` + `'unsafe-eval'` | Ace Editor、Pico.css等のCDN利用のため |
+| `style-src` | `'self'` + CDN + `'unsafe-inline'` | Pico.css、Tailwind等のCDN利用と動的スタイルのため |
+| `img-src` | `'self' data:` | インライン画像（data URI）の許可 |
+| `connect-src` | `'self'` + CDN | JSライブラリのES Module読み込みのため |
+| `worker-src` | `'self' blob:` | Ace EditorのWeb Worker対応 |
+| `frame-ancestors` | `'none'` | クリックジャッキング対策 |
+| `base-uri` | `'self'` | base要素のURL制限 |
+
+## 2つのセキュリティモード
+
+### 1. アプリケーション本体
+
+- **パス**: `/tool-files/` 以外のすべて
+- **CSP**: 完全なCSPポリシーを適用
+- **保護レベル**: 高
+
+### 2. ツール用HTML（ユーザーアップロードコンテンツ）
+
+- **パス**: `/tool-files/*`
+- **CSP**: 設定しない
+- **代替保護**: iframe sandbox属性で隔離
+
+**理由**: ツールごとに使用するCDN（Chart.js、D3.js、Three.js等）が異なり、すべてのCDNを許可リストに追加することは現実的ではないため、sandbox属性による隔離を採用しています。
+
+## コーディングガイドライン
+
+### ✅ 推奨されるパターン
+
+#### JavaScript
+
+```javascript
+// DOM APIを使用して要素を作成（XSS対策）
+const div = document.createElement('div');
+div.textContent = userInput;  // textContentは自動エスケープ
+div.className = 'my-class';
+
+// イベントハンドラはaddEventListenerで追加
+button.addEventListener('click', handleClick);
+```
+
+#### CSS
+
+```css
+/* スタイルはCSSファイルで定義 */
+.error-message {
+  color: var(--pico-color-red-500);
+}
+```
+
+### ❌ 避けるべきパターン
+
+```javascript
+// インラインHTML（XSSリスク）
+element.innerHTML = userInput;
+
+// インラインスタイル属性（将来的にCSP厳格化の障害）
+element.style.color = 'red';
+
+// インラインイベントハンドラ（CSP違反の可能性）
+element.onclick = handleClick;
+```
+
+## 将来の改善計画
+
+### Phase 1: 現状（実施済み）
+
+- `'unsafe-inline'` を許可してCDNライブラリとの互換性を確保
+- XSS対策はDOM API使用を徹底
+
+### Phase 2: インラインスタイルの排除（検討中）
+
+- すべてのインラインスタイルをCSSクラスに移行
+- `style-src` から `'unsafe-inline'` を削除可能に
+
+### Phase 3: nonce/hashベースのCSP（将来）
+
+- `'unsafe-inline'` の代わりにnonce属性またはhashを使用
+- より厳格なCSPポリシーの実現
+
+## 他のセキュリティヘッダー
+
+CSP以外にも以下のセキュリティヘッダーを設定しています：
+
+| ヘッダー | 値 | 目的 |
+|---------|-----|------|
+| `X-Content-Type-Options` | `nosniff` | MIMEスニッフィング防止 |
+| `X-Frame-Options` | `SAMEORIGIN` | クリックジャッキング対策 |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | リファラー情報の制御 |
+
+## 参考リンク
+
+- [MDN: Content Security Policy](https://developer.mozilla.org/ja/docs/Web/HTTP/CSP)
+- [OWASP: Content Security Policy Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
+- [CSP Evaluator (Google)](https://csp-evaluator.withgoogle.com/)

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -187,10 +187,39 @@ kbd {
 }
 
 /* View Switcher */
+:root {
+  --card-min-width: 300px;
+  --card-gap: 1.5rem;
+  --card-padding: 1.5rem;
+  --card-thumbnail-height: 150px;
+  --grid-min-width: 250px;
+  --grid-gap: 1rem;
+  --grid-padding: 1rem;
+  --grid-thumbnail-height: 120px;
+}
+
 .view-switcher {
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;
+}
+
+/* Select All Header */
+.select-all-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  padding: 0.5rem 0;
+}
+
+.select-all-header.hidden {
+  display: none;
+}
+
+.select-all-header label {
+  margin-bottom: 0;
+  cursor: pointer;
 }
 
 .view-btn {
@@ -213,14 +242,14 @@ kbd {
 /* Card View */
 .tools-card-view {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr));
+  gap: var(--card-gap);
 }
 
 .tool-card {
   border: 1px solid var(--pico-muted-border-color);
   border-radius: var(--pico-border-radius);
-  padding: 1.5rem;
+  padding: var(--card-padding);
   background-color: var(--pico-card-background-color);
   transition: box-shadow 0.2s ease;
 }
@@ -253,7 +282,7 @@ kbd {
 
 .tool-card-thumbnail {
   width: 100%;
-  height: 150px;
+  height: var(--card-thumbnail-height);
   background: linear-gradient(135deg, var(--pico-primary-focus) 0%, var(--pico-secondary-focus) 100%);
   border-radius: var(--pico-border-radius);
   margin-bottom: 1rem;
@@ -300,14 +329,14 @@ kbd {
 /* Grid View */
 .tools-grid-view {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(var(--grid-min-width), 1fr));
+  gap: var(--grid-gap);
 }
 
 .tool-grid-item {
   border: 1px solid var(--pico-muted-border-color);
   border-radius: var(--pico-border-radius);
-  padding: 1rem;
+  padding: var(--grid-padding);
   background-color: var(--pico-card-background-color);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
@@ -344,7 +373,7 @@ kbd {
 
 .tool-grid-thumbnail {
   width: 100%;
-  height: 120px;
+  height: var(--grid-thumbnail-height);
   background: linear-gradient(135deg, var(--pico-primary-focus) 0%, var(--pico-secondary-focus) 100%);
   border-radius: var(--pico-border-radius);
   margin-bottom: 0.75rem;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -191,6 +191,29 @@ kbd {
   color: var(--pico-color-red-500);
 }
 
+/* Type Badge */
+.type-badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.type-badge.html {
+  background-color: #E34C26;
+  color: #fff;
+}
+
+.type-badge.react {
+  background-color: #61DAFB;
+  color: #000;
+}
+
+/* Dropdown Menu */
+.dropdown-menu {
+  position: absolute;
+  z-index: 1;
+}
+
 /* View Switcher */
 :root {
   --card-min-width: 300px;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -186,6 +186,11 @@ kbd {
   box-shadow: inset 0 -1px 0 var(--pico-muted-border-color);
 }
 
+/* Error Message */
+.error-message {
+  color: var(--pico-color-red-500);
+}
+
 /* View Switcher */
 :root {
   --card-min-width: 300px;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -242,14 +242,14 @@ kbd {
 /* Card View */
 .tools-card-view {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr));
-  gap: var(--card-gap);
+  grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width, 300px), 1fr));
+  gap: var(--card-gap, 1.5rem);
 }
 
 .tool-card {
   border: 1px solid var(--pico-muted-border-color);
   border-radius: var(--pico-border-radius);
-  padding: var(--card-padding);
+  padding: var(--card-padding, 1.5rem);
   background-color: var(--pico-card-background-color);
   transition: box-shadow 0.2s ease;
 }
@@ -282,7 +282,7 @@ kbd {
 
 .tool-card-thumbnail {
   width: 100%;
-  height: var(--card-thumbnail-height);
+  height: var(--card-thumbnail-height, 150px);
   background: linear-gradient(135deg, var(--pico-primary-focus) 0%, var(--pico-secondary-focus) 100%);
   border-radius: var(--pico-border-radius);
   margin-bottom: 1rem;
@@ -329,14 +329,14 @@ kbd {
 /* Grid View */
 .tools-grid-view {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--grid-min-width), 1fr));
-  gap: var(--grid-gap);
+  grid-template-columns: repeat(auto-fill, minmax(var(--grid-min-width, 250px), 1fr));
+  gap: var(--grid-gap, 1rem);
 }
 
 .tool-grid-item {
   border: 1px solid var(--pico-muted-border-color);
   border-radius: var(--pico-border-radius);
-  padding: var(--grid-padding);
+  padding: var(--grid-padding, 1rem);
   background-color: var(--pico-card-background-color);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
@@ -373,7 +373,7 @@ kbd {
 
 .tool-grid-thumbnail {
   width: 100%;
-  height: var(--grid-thumbnail-height);
+  height: var(--grid-thumbnail-height, 120px);
   background: linear-gradient(135deg, var(--pico-primary-focus) 0%, var(--pico-secondary-focus) 100%);
   border-radius: var(--pico-border-radius);
   margin-bottom: 0.75rem;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -185,3 +185,203 @@ kbd {
   border-radius: 0.25rem;
   box-shadow: inset 0 -1px 0 var(--pico-muted-border-color);
 }
+
+/* View Switcher */
+.view-switcher {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.view-btn {
+  padding: 0.5rem 0.75rem;
+  min-width: auto;
+  margin: 0;
+}
+
+.view-btn.active {
+  background-color: var(--pico-primary);
+  color: var(--pico-primary-inverse);
+  border-color: var(--pico-primary);
+}
+
+.view-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+/* Card View */
+.tools-card-view {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.tool-card {
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: 1.5rem;
+  background-color: var(--pico-card-background-color);
+  transition: box-shadow 0.2s ease;
+}
+
+.tool-card:hover {
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+.tool-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.tool-card-checkbox {
+  margin-right: 0.5rem;
+}
+
+.tool-card-checkbox.hidden {
+  display: none;
+}
+
+.tool-card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  flex-grow: 1;
+}
+
+.tool-card-thumbnail {
+  width: 100%;
+  height: 150px;
+  background: linear-gradient(135deg, var(--pico-primary-focus) 0%, var(--pico-secondary-focus) 100%);
+  border-radius: var(--pico-border-radius);
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pico-muted-color);
+  font-size: 3rem;
+}
+
+.tool-card-description {
+  color: var(--pico-muted-color);
+  margin-bottom: 1rem;
+  min-height: 3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.tool-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tool-card-type {
+  margin-bottom: 1rem;
+}
+
+.tool-card-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tool-card-actions a,
+.tool-card-actions .dropdown {
+  flex: 1;
+  margin: 0;
+}
+
+/* Grid View */
+.tools-grid-view {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.tool-grid-item {
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: var(--pico-border-radius);
+  padding: 1rem;
+  background-color: var(--pico-card-background-color);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.tool-grid-item:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+.tool-grid-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.tool-grid-checkbox {
+  margin-right: 0.5rem;
+}
+
+.tool-grid-checkbox.hidden {
+  display: none;
+}
+
+.tool-grid-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-grid-thumbnail {
+  width: 100%;
+  height: 120px;
+  background: linear-gradient(135deg, var(--pico-primary-focus) 0%, var(--pico-secondary-focus) 100%);
+  border-radius: var(--pico-border-radius);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pico-muted-color);
+  font-size: 2.5rem;
+}
+
+.tool-grid-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tool-grid-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tool-grid-tags code {
+  font-size: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .tools-card-view {
+    grid-template-columns: 1fr;
+  }
+
+  .tools-grid-view {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+
+  .view-switcher {
+    justify-content: center;
+  }
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -131,9 +131,6 @@ document.addEventListener('DOMContentLoaded', () => {
           console.error('Fallback render also failed:', fallbackError);
         }
       }
-
-      // 削除ボタンのイベント委譲（インラインハンドラを避けてCSP準拠）
-      container.addEventListener('click', handleDeleteClick);
     } catch (error) {
       container.innerHTML =
         '<p class="error-message">ツールの読み込みに失敗しました。</p>';
@@ -519,6 +516,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Initial load（コンテナがあるページでのみ）
   if (container) {
+    // 削除ボタンのイベント委譲（一度だけ登録、インラインハンドラを避けてCSP準拠）
+    container.addEventListener('click', handleDeleteClick);
     fetchTools();
   }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -323,7 +323,10 @@ document.addEventListener('DOMContentLoaded', () => {
       gridItem.dataset.toolId = tool.id;
       gridItem.setAttribute('tabindex', '0');
       gridItem.setAttribute('role', 'button');
-      gridItem.setAttribute('aria-label', `${tool.name}を表示`);
+      gridItem.setAttribute(
+        'aria-label',
+        `${sanitizeForAttribute(tool.name)}を表示`,
+      );
 
       const header = document.createElement('div');
       header.className = 'tool-grid-header';
@@ -430,21 +433,24 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // --- Helper functions ---
+
+  // Sanitize text for safe use in attributes (removes control chars, normalizes whitespace)
+  function sanitizeForAttribute(text) {
+    if (!text) return '';
+    // Remove control characters (U+0000-U+001F, U+007F) and normalize whitespace
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control chars to sanitize
+    const controlCharRegex = /[\u0000-\u001F\u007F]/g;
+    return String(text)
+      .replace(controlCharRegex, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
   function createTypeBadge(toolType) {
     const typeBadge = document.createElement('code');
     const type = toolType || 'html';
-    if (type === 'react') {
-      typeBadge.textContent = 'React';
-      typeBadge.style.backgroundColor = '#61DAFB';
-      typeBadge.style.color = '#000';
-    } else {
-      typeBadge.textContent = 'HTML';
-      typeBadge.style.backgroundColor = '#E34C26';
-      typeBadge.style.color = '#fff';
-    }
-    typeBadge.style.padding = '0.25rem 0.5rem';
-    typeBadge.style.borderRadius = '0.25rem';
-    typeBadge.style.fontSize = '0.875rem';
+    typeBadge.className = `type-badge ${type}`;
+    typeBadge.textContent = type === 'react' ? 'React' : 'HTML';
     return typeBadge;
   }
 
@@ -467,8 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
     summary.textContent = '⋮';
 
     const ul = document.createElement('ul');
-    ul.style.position = 'absolute';
-    ul.style.zIndex = '1';
+    ul.className = 'dropdown-menu';
 
     const editLi = document.createElement('li');
     const editLink = document.createElement('a');

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -12,7 +12,49 @@ document.addEventListener('DOMContentLoaded', () => {
     'tool-operations-container',
   );
 
+  // View switcher elements
+  const viewListBtn = document.getElementById('view-list');
+  const viewCardBtn = document.getElementById('view-card');
+  const viewGridBtn = document.getElementById('view-grid');
+
   let debounceTimer;
+  let currentView = localStorage.getItem('toolViewMode') || 'list';
+
+  // --- View mode functions ---
+  function updateViewButtons() {
+    document.querySelectorAll('.view-btn').forEach((btn) => {
+      btn.classList.remove('active');
+    });
+
+    if (currentView === 'list' && viewListBtn) {
+      viewListBtn.classList.add('active');
+    } else if (currentView === 'card' && viewCardBtn) {
+      viewCardBtn.classList.add('active');
+    } else if (currentView === 'grid' && viewGridBtn) {
+      viewGridBtn.classList.add('active');
+    }
+  }
+
+  function setView(view) {
+    currentView = view;
+    localStorage.setItem('toolViewMode', view);
+    updateViewButtons();
+    fetchTools();
+  }
+
+  // Initialize view buttons
+  if (viewListBtn) {
+    viewListBtn.addEventListener('click', () => setView('list'));
+  }
+  if (viewCardBtn) {
+    viewCardBtn.addEventListener('click', () => setView('card'));
+  }
+  if (viewGridBtn) {
+    viewGridBtn.addEventListener('click', () => setView('grid'));
+  }
+
+  // Set initial view state
+  updateViewButtons();
 
   // --- ツール一覧の取得と表示 ---
   async function fetchTools() {
@@ -36,8 +78,28 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      const table = document.createElement('table');
-      table.innerHTML = `
+      container.innerHTML = '';
+
+      if (currentView === 'list') {
+        renderListView(tools);
+      } else if (currentView === 'card') {
+        renderCardView(tools);
+      } else if (currentView === 'grid') {
+        renderGridView(tools);
+      }
+
+      // 削除ボタンのイベント委譲（インラインハンドラを避けてCSP準拠）
+      container.addEventListener('click', handleDeleteClick);
+    } catch (error) {
+      container.innerHTML = `<p style="color: var(--pico-color-red-500);">ツールの読み込みに失敗しました。</p>`;
+      console.error('Error fetching tools:', error);
+    }
+  }
+
+  // --- List View Renderer ---
+  function renderListView(tools) {
+    const table = document.createElement('table');
+    table.innerHTML = `
                 <thead>
                     <tr>
                         <th class="checkbox-column hidden"><input type="checkbox" id="select-all-tools"></th>
@@ -50,135 +112,272 @@ document.addEventListener('DOMContentLoaded', () => {
                 </thead>
                 <tbody></tbody>
             `;
-      const tbody = table.querySelector('tbody');
+    const tbody = table.querySelector('tbody');
 
-      const isOperationsVisible =
-        !toolOperationsContainer.classList.contains('hidden');
+    const isOperationsVisible =
+      !toolOperationsContainer.classList.contains('hidden');
 
-      tools.forEach((tool) => {
-        const tr = document.createElement('tr');
-        tr.dataset.toolId = tool.id; // エクスポート用にIDを保持
+    tools.forEach((tool) => {
+      const tr = document.createElement('tr');
+      tr.dataset.toolId = tool.id;
 
-        const checkboxCell = document.createElement('td');
-        checkboxCell.classList.add('checkbox-column');
-        if (!isOperationsVisible) {
-          // 初期状態では非表示
-          checkboxCell.classList.add('hidden');
-        }
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.className = 'tool-checkbox';
-        checkboxCell.appendChild(checkbox);
+      const checkboxCell = document.createElement('td');
+      checkboxCell.classList.add('checkbox-column');
+      if (!isOperationsVisible) {
+        checkboxCell.classList.add('hidden');
+      }
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'tool-checkbox';
+      checkboxCell.appendChild(checkbox);
 
-        const nameCell = document.createElement('td');
-        nameCell.textContent = tool.name;
+      const nameCell = document.createElement('td');
+      nameCell.textContent = tool.name;
 
-        const descCell = document.createElement('td');
-        descCell.textContent = tool.description || '';
+      const descCell = document.createElement('td');
+      descCell.textContent = tool.description || '';
 
-        const tagsCell = document.createElement('td');
-        if (tool.tags && tool.tags.length > 0) {
-          tool.tags.forEach((tag, index) => {
-            const code = document.createElement('code');
-            code.textContent = tag;
-            tagsCell.appendChild(code);
-            if (index < tool.tags.length - 1) {
-              tagsCell.appendChild(document.createTextNode(' ')); // for spacing
-            }
-          });
-        }
-
-        const typeCell = document.createElement('td');
-        const typeBadge = document.createElement('code');
-        const toolType = tool.tool_type || 'html'; // デフォルトは html
-        if (toolType === 'react') {
-          typeBadge.textContent = 'React';
-          typeBadge.style.backgroundColor = '#61DAFB';
-          typeBadge.style.color = '#000';
-        } else {
-          typeBadge.textContent = 'HTML';
-          typeBadge.style.backgroundColor = '#E34C26';
-          typeBadge.style.color = '#fff';
-        }
-        typeBadge.style.padding = '0.25rem 0.5rem';
-        typeBadge.style.borderRadius = '0.25rem';
-        typeBadge.style.fontSize = '0.875rem';
-        typeCell.appendChild(typeBadge);
-
-        const actionsCell = document.createElement('td');
-        // XSS対策: DOM APIで安全に要素を構築
-        const actionDiv = document.createElement('div');
-        actionDiv.className = 'action-grid';
-
-        const viewLink = document.createElement('a');
-        viewLink.href = `/tools/view/${tool.id}`;
-        viewLink.setAttribute('role', 'button');
-        viewLink.className = 'secondary outline';
-        viewLink.textContent = '使用';
-
-        const dropdown = document.createElement('details');
-        dropdown.className = 'dropdown';
-
-        const summary = document.createElement('summary');
-        summary.setAttribute('role', 'button');
-        summary.className = 'contrast outline';
-        summary.textContent = '⋮';
-
-        const ul = document.createElement('ul');
-        ul.style.position = 'absolute';
-        ul.style.zIndex = '1';
-
-        const editLi = document.createElement('li');
-        const editLink = document.createElement('a');
-        editLink.href = `/tools/edit/${tool.id}`;
-        editLink.textContent = '編集';
-        editLi.appendChild(editLink);
-
-        const deleteLi = document.createElement('li');
-        const deleteLink = document.createElement('a');
-        deleteLink.href = '#';
-        deleteLink.className = 'delete-tool-btn';
-        deleteLink.dataset.toolId = tool.id;
-        deleteLink.textContent = '削除';
-        deleteLi.appendChild(deleteLink);
-
-        ul.appendChild(editLi);
-        ul.appendChild(deleteLi);
-        dropdown.appendChild(summary);
-        dropdown.appendChild(ul);
-        actionDiv.appendChild(viewLink);
-        actionDiv.appendChild(dropdown);
-        actionsCell.appendChild(actionDiv);
-
-        tr.appendChild(checkboxCell);
-        tr.appendChild(nameCell);
-        tr.appendChild(descCell);
-        tr.appendChild(tagsCell);
-        tr.appendChild(typeCell);
-        tr.appendChild(actionsCell);
-
-        tbody.appendChild(tr);
-      });
-
-      container.innerHTML = '';
-      container.appendChild(table);
-
-      // 「すべて選択」チェックボックスのイベントリスナー設定
-      const selectAllCheckbox = document.getElementById('select-all-tools');
-      if (selectAllCheckbox) {
-        selectAllCheckbox.addEventListener('change', (event) => {
-          document.querySelectorAll('.tool-checkbox').forEach((cb) => {
-            cb.checked = event.target.checked;
-          });
+      const tagsCell = document.createElement('td');
+      if (tool.tags && tool.tags.length > 0) {
+        tool.tags.forEach((tag, index) => {
+          const code = document.createElement('code');
+          code.textContent = tag;
+          tagsCell.appendChild(code);
+          if (index < tool.tags.length - 1) {
+            tagsCell.appendChild(document.createTextNode(' '));
+          }
         });
       }
 
-      // 削除ボタンのイベント委譲（インラインハンドラを避けてCSP準拠）
-      container.addEventListener('click', handleDeleteClick);
-    } catch (error) {
-      container.innerHTML = `<p style="color: var(--pico-color-red-500);">ツールの読み込みに失敗しました。</p>`;
-      console.error('Error fetching tools:', error);
+      const typeCell = document.createElement('td');
+      typeCell.appendChild(createTypeBadge(tool.tool_type));
+
+      const actionsCell = document.createElement('td');
+      actionsCell.appendChild(createActions(tool));
+
+      tr.appendChild(checkboxCell);
+      tr.appendChild(nameCell);
+      tr.appendChild(descCell);
+      tr.appendChild(tagsCell);
+      tr.appendChild(typeCell);
+      tr.appendChild(actionsCell);
+
+      tbody.appendChild(tr);
+    });
+
+    container.appendChild(table);
+
+    const selectAllCheckbox = document.getElementById('select-all-tools');
+    if (selectAllCheckbox) {
+      selectAllCheckbox.addEventListener('change', (event) => {
+        document.querySelectorAll('.tool-checkbox').forEach((cb) => {
+          cb.checked = event.target.checked;
+        });
+      });
     }
+  }
+
+  // --- Card View Renderer ---
+  function renderCardView(tools) {
+    const cardContainer = document.createElement('div');
+    cardContainer.className = 'tools-card-view';
+
+    const isOperationsVisible =
+      !toolOperationsContainer.classList.contains('hidden');
+
+    tools.forEach((tool) => {
+      const card = document.createElement('div');
+      card.className = 'tool-card';
+      card.dataset.toolId = tool.id;
+
+      const header = document.createElement('div');
+      header.className = 'tool-card-header';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'tool-checkbox tool-card-checkbox';
+      if (!isOperationsVisible) {
+        checkbox.classList.add('hidden');
+      }
+      header.appendChild(checkbox);
+
+      const title = document.createElement('h3');
+      title.className = 'tool-card-title';
+      title.textContent = tool.name;
+      header.appendChild(title);
+
+      const thumbnail = document.createElement('div');
+      thumbnail.className = 'tool-card-thumbnail';
+      thumbnail.textContent = '🛠️';
+
+      const description = document.createElement('p');
+      description.className = 'tool-card-description';
+      description.textContent = tool.description || 'No description';
+
+      const tagsDiv = document.createElement('div');
+      tagsDiv.className = 'tool-card-tags';
+      if (tool.tags && tool.tags.length > 0) {
+        tool.tags.forEach((tag) => {
+          const code = document.createElement('code');
+          code.textContent = tag;
+          tagsDiv.appendChild(code);
+        });
+      }
+
+      const typeDiv = document.createElement('div');
+      typeDiv.className = 'tool-card-type';
+      typeDiv.appendChild(createTypeBadge(tool.tool_type));
+
+      const actions = document.createElement('div');
+      actions.className = 'tool-card-actions';
+      actions.appendChild(createActions(tool));
+
+      card.appendChild(header);
+      card.appendChild(thumbnail);
+      card.appendChild(description);
+      card.appendChild(tagsDiv);
+      card.appendChild(typeDiv);
+      card.appendChild(actions);
+
+      cardContainer.appendChild(card);
+    });
+
+    container.appendChild(cardContainer);
+  }
+
+  // --- Grid View Renderer ---
+  function renderGridView(tools) {
+    const gridContainer = document.createElement('div');
+    gridContainer.className = 'tools-grid-view';
+
+    const isOperationsVisible =
+      !toolOperationsContainer.classList.contains('hidden');
+
+    tools.forEach((tool) => {
+      const gridItem = document.createElement('div');
+      gridItem.className = 'tool-grid-item';
+      gridItem.dataset.toolId = tool.id;
+
+      const header = document.createElement('div');
+      header.className = 'tool-grid-header';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'tool-checkbox tool-grid-checkbox';
+      if (!isOperationsVisible) {
+        checkbox.classList.add('hidden');
+      }
+      header.appendChild(checkbox);
+
+      const title = document.createElement('h4');
+      title.className = 'tool-grid-title';
+      title.textContent = tool.name;
+      header.appendChild(title);
+
+      const thumbnail = document.createElement('div');
+      thumbnail.className = 'tool-grid-thumbnail';
+      thumbnail.textContent = '🛠️';
+
+      // Make grid item clickable to view tool
+      gridItem.addEventListener('click', (e) => {
+        if (
+          !e.target.classList.contains('tool-checkbox') &&
+          !e.target.closest('button') &&
+          !e.target.closest('a')
+        ) {
+          window.location.href = `/tools/view/${tool.id}`;
+        }
+      });
+
+      const metaDiv = document.createElement('div');
+      metaDiv.className = 'tool-grid-meta';
+
+      const tagsDiv = document.createElement('div');
+      tagsDiv.className = 'tool-grid-tags';
+      if (tool.tags && tool.tags.length > 0) {
+        tool.tags.forEach((tag) => {
+          const code = document.createElement('code');
+          code.textContent = tag;
+          tagsDiv.appendChild(code);
+        });
+      }
+
+      metaDiv.appendChild(createTypeBadge(tool.tool_type));
+      metaDiv.appendChild(tagsDiv);
+
+      gridItem.appendChild(header);
+      gridItem.appendChild(thumbnail);
+      gridItem.appendChild(metaDiv);
+
+      gridContainer.appendChild(gridItem);
+    });
+
+    container.appendChild(gridContainer);
+  }
+
+  // --- Helper functions ---
+  function createTypeBadge(toolType) {
+    const typeBadge = document.createElement('code');
+    const type = toolType || 'html';
+    if (type === 'react') {
+      typeBadge.textContent = 'React';
+      typeBadge.style.backgroundColor = '#61DAFB';
+      typeBadge.style.color = '#000';
+    } else {
+      typeBadge.textContent = 'HTML';
+      typeBadge.style.backgroundColor = '#E34C26';
+      typeBadge.style.color = '#fff';
+    }
+    typeBadge.style.padding = '0.25rem 0.5rem';
+    typeBadge.style.borderRadius = '0.25rem';
+    typeBadge.style.fontSize = '0.875rem';
+    return typeBadge;
+  }
+
+  function createActions(tool) {
+    const actionDiv = document.createElement('div');
+    actionDiv.className = 'action-grid';
+
+    const viewLink = document.createElement('a');
+    viewLink.href = `/tools/view/${tool.id}`;
+    viewLink.setAttribute('role', 'button');
+    viewLink.className = 'secondary outline';
+    viewLink.textContent = '使用';
+
+    const dropdown = document.createElement('details');
+    dropdown.className = 'dropdown';
+
+    const summary = document.createElement('summary');
+    summary.setAttribute('role', 'button');
+    summary.className = 'contrast outline';
+    summary.textContent = '⋮';
+
+    const ul = document.createElement('ul');
+    ul.style.position = 'absolute';
+    ul.style.zIndex = '1';
+
+    const editLi = document.createElement('li');
+    const editLink = document.createElement('a');
+    editLink.href = `/tools/edit/${tool.id}`;
+    editLink.textContent = '編集';
+    editLi.appendChild(editLink);
+
+    const deleteLi = document.createElement('li');
+    const deleteLink = document.createElement('a');
+    deleteLink.href = '#';
+    deleteLink.className = 'delete-tool-btn';
+    deleteLink.dataset.toolId = tool.id;
+    deleteLink.textContent = '削除';
+    deleteLi.appendChild(deleteLink);
+
+    ul.appendChild(editLi);
+    ul.appendChild(deleteLi);
+    dropdown.appendChild(summary);
+    dropdown.appendChild(ul);
+    actionDiv.appendChild(viewLink);
+    actionDiv.appendChild(dropdown);
+
+    return actionDiv;
   }
 
   // 検索ボックスがあるページでのみイベントリスナーを登録
@@ -208,9 +407,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (toggleToolOperationsBtn) {
     toggleToolOperationsBtn.addEventListener('click', () => {
       toolOperationsContainer.classList.toggle('hidden');
+      // Update checkboxes for all view modes
       document.querySelectorAll('.checkbox-column').forEach((el) => {
         el.classList.toggle('hidden');
       });
+      document
+        .querySelectorAll('.tool-card-checkbox, .tool-grid-checkbox')
+        .forEach((el) => {
+          el.classList.toggle('hidden');
+        });
     });
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,18 @@
         </div>
     </div>
 
+    <div class="view-switcher" style="margin-bottom: 1rem;">
+        <button id="view-list" class="view-btn secondary outline" data-view="list" title="リストビュー">
+            <span class="view-icon">☰</span>
+        </button>
+        <button id="view-card" class="view-btn secondary outline" data-view="card" title="カードビュー">
+            <span class="view-icon">▦</span>
+        </button>
+        <button id="view-grid" class="view-btn secondary outline" data-view="grid" title="グリッドビュー">
+            <span class="view-icon">▦▦</span>
+        </button>
+    </div>
+
     <div style="margin-bottom: 1rem;">
         <button id="toggle-tool-operations" class="secondary outline">ツール操作を表示/非表示</button>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,15 +18,15 @@
         </div>
     </div>
 
-    <div class="view-switcher" style="margin-bottom: 1rem;">
-        <button id="view-list" class="view-btn secondary outline" data-view="list" title="リストビュー">
-            <span class="view-icon">☰</span>
+    <div class="view-switcher" style="margin-bottom: 1rem;" role="group" aria-label="表示形式の切り替え">
+        <button id="view-list" class="view-btn secondary outline" data-view="list" title="リストビュー" aria-pressed="false" aria-label="リストビュー">
+            <span class="view-icon" aria-hidden="true">☰</span>
         </button>
-        <button id="view-card" class="view-btn secondary outline" data-view="card" title="カードビュー">
-            <span class="view-icon">▦</span>
+        <button id="view-card" class="view-btn secondary outline" data-view="card" title="カードビュー" aria-pressed="false" aria-label="カードビュー">
+            <span class="view-icon" aria-hidden="true">▦</span>
         </button>
-        <button id="view-grid" class="view-btn secondary outline" data-view="grid" title="グリッドビュー">
-            <span class="view-icon">▦▦</span>
+        <button id="view-grid" class="view-btn secondary outline" data-view="grid" title="グリッドビュー" aria-pressed="false" aria-label="グリッドビュー">
+            <span class="view-icon" aria-hidden="true">▦▦</span>
         </button>
     </div>
 

--- a/tests/e2e/test_view_switcher.py
+++ b/tests/e2e/test_view_switcher.py
@@ -1,0 +1,159 @@
+"""E2E tests for view switcher functionality."""
+
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+class TestViewSwitcher:
+    """Tests for view switcher (list/card/grid) functionality."""
+
+    def test_view_buttons_exist(self, test_page: Page) -> None:
+        """View switcher buttons should be visible."""
+        expect(test_page.locator("#view-list")).to_be_visible()
+        expect(test_page.locator("#view-card")).to_be_visible()
+        expect(test_page.locator("#view-grid")).to_be_visible()
+
+    def test_list_view_default(self, test_page: Page) -> None:
+        """List view should be the default view."""
+        # List button should be active by default
+        list_btn = test_page.locator("#view-list")
+        expect(list_btn).to_have_class(re.compile(r"active"))
+        expect(list_btn).to_have_attribute("aria-pressed", "true")
+
+    def test_switch_to_card_view(self, test_page: Page, live_server: str) -> None:
+        """Clicking card view button should switch to card view."""
+        # Create a test tool first
+        self._create_test_tool(test_page, live_server)
+
+        # Navigate back to home
+        test_page.goto(live_server)
+
+        # Click card view button
+        card_btn = test_page.locator("#view-card")
+        card_btn.click()
+
+        # Card view container should be visible
+        expect(test_page.locator(".tools-card-view")).to_be_visible()
+        expect(card_btn).to_have_class(re.compile(r"active"))
+        expect(card_btn).to_have_attribute("aria-pressed", "true")
+
+    def test_switch_to_grid_view(self, test_page: Page, live_server: str) -> None:
+        """Clicking grid view button should switch to grid view."""
+        # Create a test tool first
+        self._create_test_tool(test_page, live_server)
+
+        # Navigate back to home
+        test_page.goto(live_server)
+
+        # Click grid view button
+        grid_btn = test_page.locator("#view-grid")
+        grid_btn.click()
+
+        # Grid view container should be visible
+        expect(test_page.locator(".tools-grid-view")).to_be_visible()
+        expect(grid_btn).to_have_class(re.compile(r"active"))
+        expect(grid_btn).to_have_attribute("aria-pressed", "true")
+
+    def test_view_persists_in_localstorage(self, test_page: Page, live_server: str) -> None:
+        """View preference should be saved in localStorage."""
+        # Create a test tool first
+        self._create_test_tool(test_page, live_server)
+
+        # Navigate back to home
+        test_page.goto(live_server)
+
+        # Switch to card view
+        test_page.locator("#view-card").click()
+        expect(test_page.locator(".tools-card-view")).to_be_visible()
+
+        # Reload page
+        test_page.reload()
+
+        # Card view should still be selected
+        expect(test_page.locator(".tools-card-view")).to_be_visible()
+        expect(test_page.locator("#view-card")).to_have_class(re.compile(r"active"))
+
+    def test_grid_item_keyboard_navigation(self, test_page: Page, live_server: str) -> None:
+        """Grid items should be keyboard accessible."""
+        # Create a test tool first
+        self._create_test_tool(test_page, live_server)
+
+        # Navigate back to home
+        test_page.goto(live_server)
+
+        # Switch to grid view
+        test_page.locator("#view-grid").click()
+        expect(test_page.locator(".tools-grid-view")).to_be_visible()
+
+        # Grid item should have tabindex
+        grid_item = test_page.locator(".tool-grid-item").first
+        expect(grid_item).to_have_attribute("tabindex", "0")
+        expect(grid_item).to_have_attribute("role", "button")
+
+    def test_select_all_in_card_view(self, test_page: Page, live_server: str) -> None:
+        """Select all checkbox should work in card view."""
+        # Create a test tool first
+        self._create_test_tool(test_page, live_server)
+
+        # Navigate back to home
+        test_page.goto(live_server)
+
+        # Show tool operations
+        test_page.locator("#toggle-tool-operations").click()
+
+        # Switch to card view
+        test_page.locator("#view-card").click()
+        expect(test_page.locator(".tools-card-view")).to_be_visible()
+
+        # Select all checkbox should be visible
+        select_all = test_page.locator("#select-all-tools")
+        expect(select_all).to_be_visible()
+
+        # Click select all
+        select_all.click()
+
+        # Tool checkboxes should be checked
+        tool_checkbox = test_page.locator(".tool-checkbox").first
+        expect(tool_checkbox).to_be_checked()
+
+    def test_select_all_in_grid_view(self, test_page: Page, live_server: str) -> None:
+        """Select all checkbox should work in grid view."""
+        # Create a test tool first
+        self._create_test_tool(test_page, live_server)
+
+        # Navigate back to home
+        test_page.goto(live_server)
+
+        # Show tool operations
+        test_page.locator("#toggle-tool-operations").click()
+
+        # Switch to grid view
+        test_page.locator("#view-grid").click()
+        expect(test_page.locator(".tools-grid-view")).to_be_visible()
+
+        # Select all checkbox should be visible
+        select_all = test_page.locator("#select-all-tools")
+        expect(select_all).to_be_visible()
+
+        # Click select all
+        select_all.click()
+
+        # Tool checkboxes should be checked
+        tool_checkbox = test_page.locator(".tool-checkbox").first
+        expect(tool_checkbox).to_be_checked()
+
+    def _create_test_tool(self, page: Page, live_server: str) -> None:
+        """Create a test tool for testing."""
+        page.goto(f"{live_server}/tools/create")
+        page.fill("#name", "View Test Tool")
+        page.fill("#description", "Test Description")
+
+        ace_textarea = page.locator("#code-editor textarea.ace_text-input")
+        ace_textarea.focus()
+        page.keyboard.type("<p>Hello!</p>")
+
+        page.click("#submit-btn")
+        expect(page.locator("#message")).to_contain_text("作成しました")


### PR DESCRIPTION
## 概要
ツール一覧の表示形式を切り替えられる機能を実装。

## 実装内容
- リヹトビュー（既存のテーブル形式）、カードビュー、グリッドビューの3つの表示モードを実装
- ビュー切り替えボタンをツールバーに追加
- localStorage でビュー設定を永続化
- レスポンシブ対応
- プレースホルダーサムネイルを実装

## 関連Issue
Closes #36

———
Generated with [Claude Code](https://claude.ai/code)