### PR TITLE
fix: 検索クエリに長さ制限を追加してDoS攻撃を防止

### DIFF
--- a/src/html_tool_manager/api/tools.py
+++ b/src/html_tool_manager/api/tools.py
@@ -82,7 +82,7 @@ def create_tool(tool_data: ToolCreate, session: Session = Depends(get_session)) 
 @router.get("/", response_model=List[ToolRead])
 def read_tools(
     session: Session = Depends(get_session),
-    q: Optional[str] = Query(None, description="検索クエリ（例: 'name:', 'desc:', 'tag:'）"),
+    q: Optional[str] = Query(None, max_length=500, description="検索クエリ（例: 'name:', 'desc:', 'tag:'）"),
     sort: SortOrder = Query(SortOrder.RELEVANCE, description="ソート順"),
     offset: int = Query(default=0, ge=0, description="オフセット（0以上）"),
     limit: int = Query(default=100, ge=1, le=1000, description="取得件数（1-1000）"),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -80,6 +80,24 @@ class TestDescriptionValidation:
         assert response.status_code == 201
 
 
+class TestQueryValidation:
+    """検索クエリのバリデーションテスト。"""
+
+    def test_query_too_long_returns_422(self, session: Session, client: TestClient):
+        """長すぎる検索クエリで422が返ることをテストする。"""
+        # max_length=500を超えるクエリ
+        long_query = "a" * 501
+        response = client.get(f"/api/tools/?q={long_query}")
+        assert response.status_code == 422
+
+    def test_query_at_max_length_accepted(self, session: Session, client: TestClient):
+        """最大長の検索クエリが受け入れられることをテストする。"""
+        # max_length=500のクエリ
+        max_query = "a" * 500
+        response = client.get(f"/api/tools/?q={max_query}")
+        assert response.status_code == 200
+
+
 class TestTagsValidation:
     """タグフィールドのバリデーションテスト。"""
 


### PR DESCRIPTION
## 概要

検索クエリパラメータに長さ制限を追加し、DoS攻撃のベクターを防止します。

## 変更内容

- `GET /api/tools/`の`q`パラメータに`max_length=500`を追加
- 長すぎるクエリは422エラーを返すようになった
- テストケースを追加して検証

Fixes #50

Generated with [Claude Code](https://claude.ai/code)