### PR TITLE
feat: add shared Claude Code settings for dev tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run ruff:*)",
+      "Bash(uv run ruff check:*)",
+      "Bash(uv run ruff format:*)",
+      "Bash(uv run mypy:*)",
+      "Bash(uv run ty:*)",
+      "Bash(uv run bandit:*)",
+      "Bash(uv run poe lint:*)",
+      "Bash(uv run poe typecheck:*)",
+      "Bash(uv run poe typecheck-experimental:*)",
+      "Bash(uv run poe security:*)",
+      "Bash(npx @biomejs/biome:*)"
+    ],
+    "deny": []
+  }
+}


### PR DESCRIPTION
## Summary
- Claude Code の共有用設定ファイル（`.claude/settings.json`）を追加
- 型チェック（mypy, ty）、linter/formatter（ruff, biome）、セキュリティスキャン（bandit）のコマンドを許可リストに追加

## Test plan
- [ ] Claude Code で `uv run mypy src/` が許可なしで実行できることを確認
- [ ] Claude Code で `uv run ruff check .` が許可なしで実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)